### PR TITLE
Fix config key in Toastr.php

### DIFF
--- a/src/Kamaln7/Toastr/Toastr.php
+++ b/src/Kamaln7/Toastr/Toastr.php
@@ -53,7 +53,7 @@ class Toastr {
            
             if(count($notification['options']) > 0) {
                 // Merge user supplied options with default options
-                $options = array_merge($this->config->get('toastr::config'), $notification['options']);
+                $options = array_merge($this->config->get('toastr::options'), $notification['options']);
                 // Writing options for output  
                 $output .= 'toastr.options = ' . json_encode($options) . ';';
             }

--- a/src/Kamaln7/Toastr/Toastr.php
+++ b/src/Kamaln7/Toastr/Toastr.php
@@ -53,7 +53,7 @@ class Toastr {
            
             if(count($notification['options']) > 0) {
                 // Merge user supplied options with default options
-                $options = array_merge($this->config->get('toastr::options'), $notification['options']);
+                $options = array_merge($this->config->get('toastr::config'), $notification['options']);
                 // Writing options for output  
                 $output .= 'toastr.options = ' . json_encode($options) . ';';
             }

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -1,5 +1,5 @@
 <?php
 
 return array(
-    'config' => array()
+    'options' => array()
 );


### PR DESCRIPTION
The options key doesn't exist in default config file and causes array_merge error