### PR TITLE
Update Toastr.php

### DIFF
--- a/src/Kamaln7/Toastr/Toastr.php
+++ b/src/Kamaln7/Toastr/Toastr.php
@@ -50,12 +50,17 @@ class Toastr {
 
         $output = '<script type="text/javascript">';
         foreach($notifications as $notification) {
+
+            $config = $this->config->get('toastr::options');
            
             if(count($notification['options']) > 0) {
                 // Merge user supplied options with default options
-                $options = array_merge($this->config->get('toastr::options'), $notification['options']);
-                // Writing options for output  
-                $output .= 'toastr.options = ' . json_encode($options) . ';';
+                $options = array_merge($config, $notification['options']);
+                $output .= 'toastr.options = ' . json_encode($options) . ';';   
+            }
+            else if(count($config))
+            {
+                $output .= 'toastr.options = ' . json_encode($config) . ';';   
             }
             // Toastr output
             $output .= 'toastr.' . $notification['type'] . "('" . str_replace("'", "\\'", htmlentities($notification['message'])) . "'" . (isset($notification['title']) ? ", '" . str_replace("'", "\\'", htmlentities($notification['title'])) . "'" : null) . ');';


### PR DESCRIPTION
If you added default options, they weren't applied unless you supplied a non-empty array to the Toastr-calls (e.g. Toastr::error('text', 'title', [null]). This commit fixes that.

Fixes issue #6 
